### PR TITLE
🔧fix: duckduckgo dark theme visibility

### DIFF
--- a/src/pages/content/index.tsx
+++ b/src/pages/content/index.tsx
@@ -1,4 +1,5 @@
 import { getLogseqCopliotConfig } from '@/config';
+import { fixDuckDuckGoDark } from '@/utils';
 import { createRoot } from 'react-dom/client';
 import Browser from 'webextension-polyfill';
 import { LogseqCopliot } from './LogseqCopliot';
@@ -26,6 +27,10 @@ async function run(
   searchEngine: Google | Bing | DuckDuckGo | Yandex | SearX | Baidu,
 ) {
   console.debug('Logseq copliot', window.location.hostname);
+
+  if (searchEngine instanceof DuckDuckGo) {
+    fixDuckDuckGoDark()
+  }
 
   const query = searchEngine.getQuery();
   if (query) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -83,3 +83,9 @@ export const buildTurndownService = () => {
 
   return turndownService;
 };
+
+export const fixDuckDuckGoDark = () => {
+  if (document.querySelector('.dark-bg')) {
+    document.body.style.color = 'var(--theme-col-txt-snippet)';
+  }
+}


### PR DESCRIPTION
Extension text inherits text color from the body style in all search engines, and upon changing theme, body text color got updated, but that's not the case for DuckDuckGo. So, I update the body style manually

fix for #24 