### PR TITLE
BUGFIX : The link to the github release was broken

### DIFF
--- a/src/pages/options/Options.tsx
+++ b/src/pages/options/Options.tsx
@@ -18,7 +18,7 @@ const Options = () => {
           <Heading>Logseq Copilot</Heading>
           <Text>
             <Link
-              href={`https://github.com/EINDEX/logseq-copilot/releases/tag/v${process.env.VERSION}`}
+              href={`https://github.com/EINDEX/logseq-copilot/releases/tag/${process.env.VERSION}`}
             >
               {process.env.VERSION}
             </Link>


### PR DESCRIPTION
![image](https://github.com/EINDEX/logseq-copilot/assets/199364/2659f528-959a-4dd7-8113-96f0bbaa764f)

Both the pattern *and* the revision contains a 'v' which resulted in double v in the final link (that resolve to a 404).