### PR TITLE
refactor: change time display from single digit to two digits

### DIFF
--- a/src/pages/background/index.ts
+++ b/src/pages/background/index.ts
@@ -67,9 +67,7 @@ const quickCapture = async (data: string) => {
     .replaceAll('{{url}}', activeTab.url)
     .replaceAll(
       '{{time}}',
-      `${now.getHours()}:${
-        now.getMinutes() < 10 ? '0' + now.getMinutes() : now.getMinutes()
-      }`,
+      `${now.getHours().toString().padStart(2, '0')}:${now.getMinutes().toString().padStart(2, '0')}`,
     )
     .replaceAll('{{title}}', activeTab.title)
     .trim();


### PR DESCRIPTION
## Changes

The current time display format in the application represents a single digit when the time isn't two digits. For example, 1 o'clock in the morning is represented as '1'.
This PR proposes a modification to always display time in a two-digit format. As such, the previously mentioned '1' would be represented as '01'.

## Benefits

This change maintains consistency with the **Current time** template in Logseq and enables users to read time more naturally. In addition, the consistency of time data will be further enhanced, thereby improving user experience.
