### PR TITLE
fix: "To block" link throwing error when opening in Logseq #56

### DIFF
--- a/src/pages/logseq/client.ts
+++ b/src/pages/logseq/client.ts
@@ -367,7 +367,8 @@ export default class LogseqClient {
           pageSet.add(page.name);
           result.pages.push(page);
         }
-      });
+      })
+      result.graph = result.graph || search.graph;
     });
     return result;
   };


### PR DESCRIPTION
fix #56