### PR TITLE
docs: fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Logseq Copilot is an open-source project and welcomes contributions from anyone 
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=eindex/logseq-copilot&type=Date)](https://star-history.com/#eindex/logseq-copilot&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=eindex/logseq-copilot&type=Date)](https://star-history.dera.page/#eindex/logseq-copilot&Date)
 
 ## License
 


### PR DESCRIPTION
The star history chart in the README is currently broken because it relies on the old GitHub stargazer API. This change points the chart to a working alternative data source so the chart renders correctly again. It only affects the star history chart image and its link; all other badges are left untouched.